### PR TITLE
APX EGPRs state save/restoration validation during VM initialization.

### DIFF
--- a/src/hotspot/cpu/x86/vm_version_x86.hpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.hpp
@@ -325,8 +325,10 @@ protected:
 
   static bool _has_intel_jcc_erratum;
 
-  static address   _cpuinfo_segv_addr; // address of instruction which causes SEGV
-  static address   _cpuinfo_cont_addr; // address of instruction after the one which causes SEGV
+  static address   _cpuinfo_segv_addr;     // address of instruction which causes SEGV
+  static address   _cpuinfo_cont_addr;     // address of instruction after the one which causes SEGV
+  static address   _cpuinfo_segv_addr_apx; // address of instruction which causes APX specific SEGV
+  static address   _cpuinfo_cont_addr_apx; // address of instruction which causes APX specific SEGV
 
   /*
    * Update following files when declaring new flags:
@@ -599,12 +601,20 @@ public:
 
   // The value used to check ymm register after signal handle
   static int ymm_test_value()    { return 0xCAFEBABE; }
+  static long long egpr_test_value()   { return 0xCAFEBABECAFEBABEULL; }
 
   static void get_cpu_info_wrapper();
   static void set_cpuinfo_segv_addr(address pc) { _cpuinfo_segv_addr = pc; }
   static bool  is_cpuinfo_segv_addr(address pc) { return _cpuinfo_segv_addr == pc; }
   static void set_cpuinfo_cont_addr(address pc) { _cpuinfo_cont_addr = pc; }
   static address  cpuinfo_cont_addr()           { return _cpuinfo_cont_addr; }
+
+  static void set_cpuinfo_segv_addr_apx(address pc) { _cpuinfo_segv_addr_apx = pc; }
+  static bool  is_cpuinfo_segv_addr_apx(address pc) { return _cpuinfo_segv_addr_apx == pc; }
+  static void set_cpuinfo_cont_addr_apx(address pc) { _cpuinfo_cont_addr_apx = pc; }
+  static address  cpuinfo_cont_addr_apx()           { return _cpuinfo_cont_addr_apx; }
+
+  static void clear_apx_test_state();
 
   static void clean_cpuFeatures()   { _features = 0; }
   static void set_avx_cpuFeatures() { _features = (CPU_SSE | CPU_SSE2 | CPU_AVX | CPU_VZEROUPPER ); }

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -2668,6 +2668,13 @@ LONG WINAPI topLevelExceptionFilter(struct _EXCEPTION_POINTERS* exceptionInfo) {
     // Verify that OS save/restore AVX registers.
     return Handle_Exception(exceptionInfo, VM_Version::cpuinfo_cont_addr());
   }
+
+  if ((exception_code == EXCEPTION_ACCESS_VIOLATION) &&
+      VM_Version::is_cpuinfo_segv_addr_apx(pc)) {
+    // Verify that OS save/restore APX registers.
+    VM_Version::clear_apx_test_state();
+    return Handle_Exception(exceptionInfo, VM_Version::cpuinfo_cont_addr_apx());
+  }
 #endif
 
   if (t != nullptr && t->is_Java_thread()) {

--- a/src/hotspot/os_cpu/bsd_x86/os_bsd_x86.cpp
+++ b/src/hotspot/os_cpu/bsd_x86/os_bsd_x86.cpp
@@ -417,6 +417,12 @@ bool PosixSignals::pd_hotspot_signal_handler(int sig, siginfo_t* info,
       stub = VM_Version::cpuinfo_cont_addr();
     }
 
+    if ((sig == SIGSEGV) && VM_Version::is_cpuinfo_segv_addr_apx(pc)) {
+      // Verify that OS save/restore APX registers.
+      stub = VM_Version::cpuinfo_cont_addr_apx();
+      VM_Version::clear_apx_test_state();
+    }
+
     // We test if stub is already set (by the stack overflow code
     // above) so it is not overwritten by the code that follows. This
     // check is not required on other platforms, because on other

--- a/src/hotspot/os_cpu/linux_x86/os_linux_x86.cpp
+++ b/src/hotspot/os_cpu/linux_x86/os_linux_x86.cpp
@@ -249,6 +249,12 @@ bool PosixSignals::pd_hotspot_signal_handler(int sig, siginfo_t* info,
       stub = VM_Version::cpuinfo_cont_addr();
     }
 
+    if ((sig == SIGSEGV) && VM_Version::is_cpuinfo_segv_addr_apx(pc)) {
+      // Verify that OS save/restore APX registers.
+      stub = VM_Version::cpuinfo_cont_addr_apx();
+      VM_Version::clear_apx_test_state();
+    }
+
     if (thread->thread_state() == _thread_in_Java) {
       // Java thread running in Java code => find exception handler if any
       // a fault inside compiled code, the interpreter, or a stub


### PR DESCRIPTION
Summary of changes:

- Support synthetic EGPR state saving / restoration validation during VM initialization.
- Fix incorrect condition for enabling UseAPX flag.

In real environment JVM depends on APX enabled OS for state preservation during thread context switches and signal handling.

Kindly integrate after review.

Best Regards,
Jatin